### PR TITLE
Fix proc groups syntax deprecation warning

### DIFF
--- a/font_base.odin
+++ b/font_base.odin
@@ -300,7 +300,7 @@ parse_string_provided :: proc(using font: ^Font, str: string, ask_size: int, pal
     return num, max_cursor_x, cursor_y;
 }
 
-parse_string :: proc[parse_string_provided, parse_string_allocate];
+parse_string :: proc{parse_string_provided, parse_string_allocate};
 
 
 save_as_png :: proc(using font: ^Font) {

--- a/font_opengl.odin
+++ b/font_opengl.odin
@@ -194,7 +194,7 @@ draw_string_palette :: inline proc(font: ^Font, size: int, at: [2]f32, palette: 
 	return num, dx, dy;
 }
 
-draw_string :: proc[draw_string_palette, draw_string_nopalette];
+draw_string :: proc{draw_string_palette, draw_string_nopalette};
 
 vertex_shader_source := `
 #version 430 core


### PR DESCRIPTION
Procedure groups now use {} instead of [] to be more in line with bit sets.